### PR TITLE
add linting and fmt to pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,10 @@
 repos:
   - repo: https://github.com/tateexon/pre-commit-hooks
-    rev: db078105fc8d83f45efb47043c0d586b856b6108 # v0.0.1
+    rev: f3a26e1675b64927002fd342228e64de8d43e0fa # v0.0.2
     hooks:
       - id: detect-typos
+      - id: rust-lint
+      - id: rust-fmt
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c # v4.6.0
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: lint
 lint:
-	cargo clippy
+	cargo clippy -- -D warnings
 	cargo fmt
 
 .PHONY: build

--- a/src/vec/flat_vec_2d.rs
+++ b/src/vec/flat_vec_2d.rs
@@ -8,12 +8,18 @@ pub fn get_2d_coordinates(index: usize, width: usize) -> (usize, usize) {
     (x, y)
 }
 
-pub fn get_2d_value<T: Copy>(vec: &Vec<T>, x: usize, y: usize, width: usize) -> Option<T> {
+pub fn get_2d_value<T: Copy>(vec: &[T], x: usize, y: usize, width: usize) -> Option<T> {
     let index = get_2d_index(x, y, width);
     vec.get(index).copied()
 }
 
-fn insert_2d_value<T: Copy>(vec: &mut Vec<T>, x: usize, y: usize, width: usize, value: T) -> Result<(), &'static str> {
+pub fn insert_2d_value<T: Copy>(
+    vec: &mut [T],
+    x: usize,
+    y: usize,
+    width: usize,
+    value: T,
+) -> Result<(), &'static str> {
     let index = get_2d_index(x, y, width);
     if index < vec.len() {
         vec[index] = value;


### PR DESCRIPTION
Setting default as warnings as errors for cargo clippy
Use pre-commit checks to verify fmt and lint on commit and push